### PR TITLE
Update modulefinder to compile on riscv

### DIFF
--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -375,10 +375,12 @@ try_append_module(sentry_value_t modules, const sentry_module_t *module)
 // copied from:
 // https://github.com/google/breakpad/blob/216cea7bca53fa441a3ee0d0f5fd339a3a894224/src/client/linux/minidump_writer/linux_dumper.h#L61-L70
 #if defined(__i386) || defined(__ARM_EABI__)                                   \
-    || (defined(__mips__) && _MIPS_SIM == _ABIO32)
+    || (defined(__mips__) && _MIPS_SIM == _ABIO32)                             \
+    || (defined(__riscv) && __riscv_xlen == 32)
 typedef Elf32_auxv_t elf_aux_entry;
-#elif defined(__x86_64) || defined(__aarch64__)                                \
-    || (defined(__mips__) && _MIPS_SIM != _ABIO32)
+#elif defined(__x86_64) || defined(__aarch64__)                               \
+    || (defined(__mips__) && _MIPS_SIM != _ABIO32)                            \
+    || (defined(__riscv) && __riscv_xlen == 64)
 typedef Elf64_auxv_t elf_aux_entry;
 #endif
 


### PR DESCRIPTION
Fix ifdef to point to correct type for riscv64