### PR TITLE
Include sanitizer/msan_interface.h for __msan_unpoison()

### DIFF
--- a/src/sentry_unix_pageallocator.c
+++ b/src/sentry_unix_pageallocator.c
@@ -12,6 +12,14 @@
 
 #define ALIGN 8
 
+#define __msan_unpoison(X, Y) // NOLINT
+#if defined(__has_feature)
+#    if __has_feature(memory_sanitizer)
+#        undef __msan_unpoison
+#        include <sanitizer/msan_interface.h>
+#    endif
+#endif
+
 struct page_header;
 struct page_header {
     struct page_header *next;
@@ -60,11 +68,7 @@ get_pages(size_t num_pages)
         return NULL;
     }
 
-#if defined(__has_feature)
-#    if __has_feature(memory_sanitizer)
     __msan_unpoison(rv, g_alloc->page_size * num_pages);
-#    endif
-#endif
 
     struct page_header *header = (struct page_header *)rv;
     header->next = g_alloc->last_page;


### PR DESCRIPTION
Clang-15 now complains [1]:

    Sep 06 18:49:22 FAILED: contrib/sentry-native-cmake/CMakeFiles/_sentry.dir/__/sentry-native/src/sentry_unix_pageallocator.c.o
    Sep 06 18:49:22 /usr/bin/ccache /usr/bin/clang-15 --target=x86_64-linux-gnu --sysroot=/build/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -DHAS_RESERVED_IDENTIFIER -DSENTRY_BUILD_STATIC -DSENTRY_WITH_INPROC_BACKEND -DSIZEOF_LONG=8 -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -I../contrib/sentry-native/include -I../contrib/sentry-native/src -I../base/glibc-compatibility/memcpy -isystem ../contrib/libcxx/include -isystem ../contrib/libcxxabi/include -isystem ../contrib/libunwind/include -isystem ../contrib/curl/include -isystem ../contrib/curl/lib -isystem ../contrib/curl-cmake/. --gcc-toolchain=/build/cmake/linux/../../contrib/sysroot/linux-x86_64  -g -fno-omit-frame-pointer -DSANITIZER -fsanitize=memory -fsanitize-memory-use-after-dtor -fsanitize-memory-track-origins -fno-optimize-sibling-calls -fsanitize-blacklist=/build/tests/msan_suppressions.txt -fdiagnostics-color=always -Xclang -fuse-ctor-homing  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/build=. -falign-functions=32 -mbranches-within-32B-boundaries  -fdiagnostics-absolute-paths -fexperimental-new-pass-manager -w -O2 -g -DNDEBUG -O3 -g -gdwarf-4  -fno-pie   -D OS_LINUX -Werror -std=gnu11 -MD -MT contrib/sentry-native-cmake/CMakeFiles/_sentry.dir/__/sentry-native/src/sentry_unix_pageallocator.c.o -MF contrib/sentry-native-cmake/CMakeFiles/_sentry.dir/__/sentry-native/src/sentry_unix_pageallocator.c.o.d -o contrib/sentry-native-cmake/CMakeFiles/_sentry.dir/__/sentry-native/src/sentry_unix_pageallocator.c.o   -c ../contrib/sentry-native/src/sentry_unix_pageallocator.c
    Sep 06 18:49:22 /build/contrib/sentry-native/src/sentry_unix_pageallocator.c:65:5: error: call to undeclared function '__msan_unpoison'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    Sep 06 18:49:22     __msan_unpoison(rv, g_alloc->page_size * num_pages);
    Sep 06 18:49:22     ^

  [1]: https://s3.amazonaws.com/clickhouse-builds/41046/0e9265ad951d40cdce3716fb8a679360b2e0c156/package_msan/build_log.log

Refs: https://github.com/ClickHouse/ClickHouse/pull/41046