### PR TITLE
add loongarch support

### DIFF
--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -376,11 +376,13 @@ try_append_module(sentry_value_t modules, const sentry_module_t *module)
 // https://github.com/google/breakpad/blob/216cea7bca53fa441a3ee0d0f5fd339a3a894224/src/client/linux/minidump_writer/linux_dumper.h#L61-L70
 #if defined(__i386) || defined(__ARM_EABI__)                                   \
     || (defined(__mips__) && _MIPS_SIM == _ABIO32)                             \
-    || (defined(__riscv) && __riscv_xlen == 32)
+    || (defined(__riscv) && __riscv_xlen == 32)                                \
+    || (defined(__loongarch__) && __loongarch_grlen == 32)
 typedef Elf32_auxv_t elf_aux_entry;
 #elif defined(__x86_64) || defined(__aarch64__)                               \
     || (defined(__mips__) && _MIPS_SIM != _ABIO32)                            \
-    || (defined(__riscv) && __riscv_xlen == 64) || (defined(__s390x__))
+    || (defined(__riscv) && __riscv_xlen == 64) || (defined(__s390x__))       \
+    || (defined(__loongarch__) && __loongarch_grlen == 64)
 typedef Elf64_auxv_t elf_aux_entry;
 #endif
 


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html