### PR TITLE
Add ability to disable page allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ endif()
 
 option(SENTRY_PIC "Build sentry (and dependent) libraries as position independent libraries" ON)
 
+option(SENTRY_ENABLE_PAGE_ALLOCATOR "Enable page allocator (does not works on non-unix)" ${CMAKE_HOST_UNIX})
+
 option(SENTRY_BUILD_TESTS "Build sentry-native tests" "${SENTRY_MAIN_PROJECT}")
 option(SENTRY_BUILD_EXAMPLES "Build sentry-native example(s)" "${SENTRY_MAIN_PROJECT}")
 
@@ -291,6 +293,10 @@ if(SENTRY_TRANSPORT_CURL)
 		target_link_libraries(sentry PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_LIBRARIES}>)
 		target_compile_definitions(sentry PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_COMPILE_DEFINITIONS}>)
 	endif()
+endif()
+
+if(SENTRY_ENABLE_PAGE_ALLOCATOR)
+	target_compile_definitions(sentry PRIVATE SENTRY_ENABLE_PAGE_ALLOCATOR)
 endif()
 
 set_property(TARGET sentry PROPERTY C_VISIBILITY_PRESET hidden)

--- a/src/sentry_alloc.c
+++ b/src/sentry_alloc.c
@@ -5,15 +5,14 @@
 
 /* on unix platforms we add support for a simplistic page allocator that can
    be enabled to make code async safe */
-#ifdef SENTRY_PLATFORM_UNIX
+#ifdef SENTRY_ENABLE_PAGE_ALLOCATOR
 #    include "sentry_unix_pageallocator.h"
-#    define WITH_PAGE_ALLOCATOR
 #endif
 
 void *
 sentry_malloc(size_t size)
 {
-#ifdef WITH_PAGE_ALLOCATOR
+#ifdef SENTRY_ENABLE_PAGE_ALLOCATOR
     if (sentry__page_allocator_enabled()) {
         return sentry__page_allocator_alloc(size);
     }
@@ -24,7 +23,7 @@ sentry_malloc(size_t size)
 void
 sentry_free(void *ptr)
 {
-#ifdef WITH_PAGE_ALLOCATOR
+#ifdef SENTRY_ENABLE_PAGE_ALLOCATOR
     /* page allocator can't free */
     if (sentry__page_allocator_enabled()) {
         return;


### PR DESCRIPTION
This is required to avoid leaks, since free() with page allocator is noop.

Required-for: https://github.com/ClickHouse/ClickHouse/pull/61997
Upstream: https://github.com/getsentry/sentry-native/pull/979